### PR TITLE
fix django version to 1.2.5 in testsuite

### DIFF
--- a/tests/buildout.cfg
+++ b/tests/buildout.cfg
@@ -1,15 +1,16 @@
 [buildout]
+versions = versions
 develop = 
     ../../django-multilingual-ng
 parts =
     python
     django
 eggs =
+    Django
     django-multilingual-ng
 
 [django]
 recipe = djangorecipe
-version = 1.2-beta-1
 project = testproject
 settings = settings
 eggs = ${buildout:eggs}
@@ -20,3 +21,7 @@ test =
 recipe = zc.recipe.egg
 interpreter = python
 eggs = ${buildout:eggs}
+
+[versions]
+Django = 1.2.5
+


### PR DESCRIPTION
updated buildout.cfg setup for newer djangorecipe
